### PR TITLE
Deletes Hot Stories section from Blog Archive

### DIFF
--- a/archive.html
+++ b/archive.html
@@ -12,42 +12,6 @@ permalink: /archive/
 -->
 {% endcomment -%}
 
-<section class="archive-page">
-    <h2>Hot Stories</h2>
-    <ol>
-        <li><a href="{{ "/2020/01/16/eth2-quick-update-no-7/" | prepend: site.baseurl }}" class="post-title">
-            eth2 quick update no. 7
-        </a></li>
-        <li><a href="{{ "/2019/12/23/ethereum-muir-glacier-upgrade-announcement/" | prepend: site.baseurl }}" class="post-title">
-            Ethereum Muir Glacier Upgrade Announcement
-        </a></li>
-        <li><a href="{{ "/2020/02/04/eth2-quick-update-no-8/" | prepend: site.baseurl }}" class="post-title">
-            eth2 quick update no. 8
-        </a></li>
-        <li><a href="{{ "/2020/01/13/validated-staking-on-eth2-1-incentives/" | prepend: site.baseurl }}" class="post-title">
-            Validated, staking on eth2: #1 - Incentives
-        </a></li>
-        <li><a href="{{ "/2020/01/08/update-on-the-vyper-compiler/" | prepend: site.baseurl }}" class="post-title">
-            Update on the Vyper Compiler
-        </a></li>
-        <li><a href="{{ "/2019/12/30/eth1x-files-state-of-stateless-ethereum/" | prepend: site.baseurl }}" class="post-title">
-            The 1.x Files: The State of Stateless Ethereum
-        </a></li>
-        <li><a href="{{ "/2020/02/12/validated-staking-on-eth2-2-two-ghosts-in-a-trench-coat/" | prepend: site.baseurl }}" class="post-title">
-            Validated, staking on eth2: #2 - Two ghosts in a trench coat
-        </a></li>
-        <li><a href="{{ "/2020/01/17/eth1x-files-digest-no-2/" | prepend: site.baseurl }}" class="post-title">
-            The 1.x Files: January call digest
-        </a></li>
-        <li><a href="{{ "/2020/01/28/eth1x-files-the-stateless-ethereum-tech-tree/" | prepend: site.baseurl }}" class="post-title">
-            The 1.x Files: The Stateless Ethereum Tech Tree
-        </a></li>
-        <li><a href="{{ "/2016/12/05/zksnarks-in-a-nutshell/" | prepend: site.baseurl }}" class="post-title">
-            zkSNARKs in a nutshell
-        </a></li>
-        
-    </ol>
-
 </section>
 
 {% assign currentYear = site.posts[0].date | date: '%Y' %}


### PR DESCRIPTION
The "Hot Stories" section contains manually selected blog posts from the Ethereum blog, which doesn't really make sense for the Solidity blog archive. 