### PR TITLE
Fixing builds: updating to latest octokit library

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
     execjs (2.7.0)
-    faraday (1.0.0)
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.12.2)
     forwardable-extended (2.6.0)
@@ -205,17 +205,17 @@ GEM
     multipart-post (2.1.1)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
-    octokit (4.17.0)
+    octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (3.1.1)
-    rb-fsevent (0.10.3)
+    rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rouge (3.13.0)
-    ruby-enum (0.7.2)
+    ruby-enum (0.8.0)
       i18n
     rubyzip (2.3.0)
     safe_yaml (1.0.5)
@@ -230,9 +230,9 @@ GEM
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
-    typhoeus (1.3.1)
+    typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
 
@@ -244,4 +244,4 @@ DEPENDENCIES
   jekyll-paginate
 
 BUNDLED WITH
-   1.16.6
+   2.1.4

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     <<: *defaults
     docker:
-      - image: circleci/ruby:2.5
+      - image: circleci/ruby:2.6.0-node
     environment:
       BUNDLE_PATH: ~/repo/vendor/bundle
     steps:
@@ -14,6 +14,9 @@ jobs:
           keys:
             - rubygems-v1-{{ checksum "Gemfile.lock" }}
             - rubygems-v1-fallback
+      - run:
+          name: Bundle gem install
+          command: gem install bundler:2.1.4
       - run:
           name: Bundle Install
           command: bundle check || bundle install


### PR DESCRIPTION
Both circleCI and Netlify are having this error:
> 10:57:42 AM: Your bundle is locked to **octokit (4.17.0)**, but that version could not be found
10:57:42 AM: in any of the sources listed in your Gemfile. 

Octokit is a library maintained by GitHub, and got pulled from the Rubygems package registry.
![image](https://user-images.githubusercontent.com/47108/81839942-4228a300-9516-11ea-8dda-ecc6e9e8bf8d.png).
Source: https://rubygems.org/gems/octokit/versions