### PR TITLE
Adds categories, EF blog links and aligns header rules of posts

### DIFF
--- a/_posts/2016-06-10-smart-contract-security.md
+++ b/_posts/2016-06-10-smart-contract-security.md
@@ -1,10 +1,13 @@
 ---
-id: 2729
-title: Smart Contract Security
-date: 2016-06-10T18:27:17+00:00
-author: Christian Reitwiessner
 layout: post
+published: true
+title: 'Smart Contract Security'
+date: '2016-06-10'
+author: Christian Reitwiessner
+category: Security Alerts
 ---
+_This post was originally published on the [Ethereum blog](https://blog.ethereum.org/2016/06/10/smart-contract-security/)._
+
 Solidity was started in October 2014 when neither the Ethereum network nor the virtual machine had any real-world testing, the gas costs at that time were even drastically different from what they are now. Furthermore, some of the early design decisions were taken over from Serpent. During the last couple of months, examples and patterns that were initially considered best-practice were exposed to reality and some of them actually turned out to be anti-patterns. Due to that, we recently updated some of the <a href="https://solidity.readthedocs.org">Solidity documentation</a>, but as most people probably do not follow the stream of github commits to that repository, I would like to highlight some of the findings here.
 
 I will not talk about the minor issues here, please read up on them in the <a href="http://solidity.readthedocs.io/en/latest/miscellaneous.html#pitfalls">documentation</a>.

--- a/_posts/2016-09-01-formal-methods-roadmap.md
+++ b/_posts/2016-09-01-formal-methods-roadmap.md
@@ -1,10 +1,13 @@
 ---
-id: 3227
-title: 'Dev Update: Formal Methods'
-date: 2016-09-01T19:55:01+00:00
-author: Christian Reitwiessner
 layout: post
+published: true
+title: 'Dev Update: Formal Methods'
+date: '2016-09-01'
+author: Christian Reitwiessner
+category: Announcements
 ---
+_This post was originally published on the [Ethereum blog](https://blog.ethereum.org/2016/09/01/formal-methods-roadmap/)._
+
 Today, I am delighted to announce that Yoichi Hirai (<a href="https://github.com/pirapira">pirapira</a> on github) is joining the Ethereum project as a formal verification engineer. He holds a PhD from the University of Tokyo on the topic of formalizing communicating parallel processes and created formal verification tools for Ethereum in his spare time.
 
 In his own words:

--- a/_posts/2016-11-01-security-alert-solidity-variables-can-overwritten-storage.md
+++ b/_posts/2016-11-01-security-alert-solidity-variables-can-overwritten-storage.md
@@ -1,12 +1,13 @@
 ---
-id: 3363
-title: 'Security Alert: Variables can be overwritten in storage'
-date: 2016-11-01T08:40:44+00:00
-author: Christian Reitwiessner
 layout: post
-guid: https://blog.ethereum.org/?p=3363
-permalink: /2016/11/01/security-alert-solidity-variables-can-overwritten-storage/
+published: true
+title: 'Security Alert: Variables can be overwritten in storage'
+date: '2016-11-01'
+author: Christian Reitwiessner
+category: Security Alerts
 ---
+_This post was originally published on the [Ethereum blog](https://blog.ethereum.org/2016/11/01/security-alert-solidity-variables-can-overwritten-storage/)._
+
 <strong>Summary:</strong> In some situations, variables can overwrite other variables in storage.
 
 <strong>Affected Solidity compiler versions: </strong>0.1.6 to 0.4.3 (including 0.4.4 pre-release versions)

--- a/_posts/2017-05-03-solidity-optimizer-bug.md
+++ b/_posts/2017-05-03-solidity-optimizer-bug.md
@@ -1,10 +1,13 @@
 ---
-id: 3831
-title: Solidity Optimizer Bug
-date: 2017-05-03T15:21:57+00:00
-author: Martin Swende
 layout: post
+published: true
+title: 'Solidity Optimizer Bug'
+date: '2017-05-03'
+author: Martin Swende
+category: Security Alerts
 ---
+_This post was originally published on the [Ethereum blog](https://blog.ethereum.org/2017/05/03/solidity-optimizer-bug/)._
+
 A bug in the Solidity optimizer was reported through the <a href="https://bounty.ethereum.org/" target="_blank">Ethereum Foundation Bounty program</a>, by Christoph Jentzsch. This bug is patched as of 2017-05-03, with the release of Solidity 0.4.11.
 <h2 id="background" class="part" data-startline="5" data-endline="5">Background</h2>
 <p class="part" data-startline="7" data-endline="7">The bug in question concerned how the optimizer optimizes on constants in the byte code. By "byte code constants", we mean anything which is <code>PUSH</code>ed on the stack (not to be confused with Solidity constants). For example, if the value <code>0xfffffffffffffffffffffffffffffffffffffffffffffffe</code> is <code>PUSH</code>ed, then the optimizer can either do <code>PUSH32 0xfffffffffffffffffffffffffffffffffffffffffffffffe</code>, or choose to encode this as <code>PUSH1 1; NOT;</code>.</p>

--- a/_posts/2018-09-13-solidity-bugfix-release.md
+++ b/_posts/2018-09-13-solidity-bugfix-release.md
@@ -1,10 +1,12 @@
 ---
 layout: post
 published: true
-title: Solidity Bugfix Release
+title: 'Solidity Bugfix Release'
 date: '2018-09-13'
 author: Solidity Team
+category: Security Alerts
 ---
+_This post was originally published on the [Ethereum blog](https://blog.ethereum.org/2018/09/13/solidity-bugfix-release/)._
 
 The latest [version 0.4.25 release of Solidity](https://github.com/ethereum/solidity/releases/tag/v0.4.25) fixes
 two important bugs.

--- a/_posts/2019-03-26-solidity-optimizer-and-abiencoderv2-bug.md
+++ b/_posts/2019-03-26-solidity-optimizer-and-abiencoderv2-bug.md
@@ -1,11 +1,12 @@
 ---
 layout: post
 published: true
-title: Solidity Optimizer and ABIEncoderV2 Bugs
-subtitle:
+title: 'Solidity Optimizer and ABIEncoderV2 Bugs'
 date: '2019-03-26'
 author: Solidity and Security Team
+category: Security Alerts
 ---
+_This post was originally published on the [Ethereum blog](https://blog.ethereum.org/2019/03/26/solidity-optimizer-and-abiencoderv2-bug/)._
 
 Through the Ethereum bug bounty program, we received a report about a flaw within the new experimental ABI encoder (referred to as ABIEncoderV2). Upon investigation, it was found that the component suffers from a few different variations of the same type. The first part of this announcement explains this bug in detail. The new ABI encoder is still marked as experimental, but we nevertheless think that this deserves a prominent announcement since it is already used on mainnet.
 

--- a/_posts/2019-06-25-solidity-storage-array-bugs.md
+++ b/_posts/2019-06-25-solidity-storage-array-bugs.md
@@ -1,11 +1,12 @@
 ---
 layout: post
 published: true
-title: Solidity Storage Array Bugs
-subtitle:
+title: 'Solidity Storage Array Bugs'
 date: '2019-06-25'
 author: Solidity and Security Team
+category: Security Alerts
 ---
+_This post was originally published on the [Ethereum blog](https://blog.ethereum.org/2019/06/25/solidity-storage-array-bugs/)._
 
 This blog post is about two bugs connected to storage arrays which are otherwise unrelated. Both have been present in the compiler for a long time and have only been discovered now even though a contract containing them should very likely show malfunctions in tests.
 

--- a/_posts/2020-01-29-solidity-0.6-try-catch.md
+++ b/_posts/2020-01-29-solidity-0.6-try-catch.md
@@ -4,7 +4,9 @@ published: true
 title: 'Solidity 0.6.x features: try/catch statement'
 date: '2020-01-29'
 author: Elena Gesheva
+category: Explainers
 ---
+_This post was originally published on the [Ethereum blog](https://blog.ethereum.org/2020/01/29/solidity-0.6-try-catch/)._
 
 The [try/catch syntax introduced in 0.6.0](https://solidity.readthedocs.io/en/latest/control-structures.html#try-catch) is arguably the biggest leap in error handling capabilities in Solidity, since reason strings for ``revert`` and ``require`` were released in v0.4.22. Both ``try`` and ``catch`` have been reserved keywords [since v0.5.9](https://solidity.readthedocs.io/en/v0.5.9/miscellaneous.html#reserved-keywords) and now we can use them to handle failures in ``external`` function calls without rolling back the complete transaction (state changes in the called function are still rolled back, but the ones in the calling function are not).
 

--- a/_posts/2020-03-23-fallback-receive-split.md
+++ b/_posts/2020-03-23-fallback-receive-split.md
@@ -1,8 +1,10 @@
 ---
 layout: post
-title:  "Solidity 0.6.x features: fallback and receive functions"
-date:   2020-03-26
+published: true
+title: 'Solidity 0.6.x features: fallback and receive functions'
+date: '2020-03-26'
 author: Elena Gesheva
+category: Explainers
 ---
 
 In versions of Solidity before 0.6.x, developers typically used the [fallback function](https://solidity.readthedocs.io/en/v0.5.15/contracts.html#fallback-function) to handle logic in two scenarios:

--- a/_posts/2020-04-06-memory-creation-overflow-bug.md
+++ b/_posts/2020-04-06-memory-creation-overflow-bug.md
@@ -1,8 +1,10 @@
 ---
 layout: post
+published: true
 title:  "Solidity Memory Array Creation Overflow Bug"
 date:   2020-04-06
 author: Solidity Team
+category: Security Alerts
 ---
 
 On the 28th of March, a bug in the Solidity code generator was reported through the

--- a/_posts/2020-04-17-Solidity-Summit-2020-Goes-Interspace.md
+++ b/_posts/2020-04-17-Solidity-Summit-2020-Goes-Interspace.md
@@ -4,7 +4,7 @@ published: true
 title: 'Solidity Summit 2020 Goes Interspace'
 date: '2020-04-17'
 author: Franziska Heintel
-category:
+category: Announcements
 ---
 
 **Tl;dr:** As already [announced on Twitter](https://twitter.com/solidity_lang/status/1244645576735690752?s=20), we transformed the Solidity Summit, which was initially planned to be an in-person meeting in Berlin, into an online event. Today, we are excited to share that the summit will be powered by [Interspace.Chat](https://github.com/interspacechat/interspace.chat). Interspace is a virtual meeting infrastructure based on self-hosted [Jitsi](https://jitsi.org/) video chat rooms. Check out the Solidity Summit's preliminary event agenda [here](https://docs.google.com/spreadsheets/d/1ylkaTYKx9TbAifCgyH2jN9SKJKrYfzab9zzTZgSL44g/edit#gid=2065734219) and make sure to [register](https://solidity-summit.ethereum.org/) if you want to partipate!

--- a/_posts/2020-05-13-immutable-keyword.md
+++ b/_posts/2020-05-13-immutable-keyword.md
@@ -4,7 +4,7 @@ published: true
 title: 'Solidity 0.6.x features: Saving Storage Costs with Immutables'
 date: '2020-05-13'
 author: Daniel Kirchner
-category:
+category: Explainers
 ---
 
 With [version 0.6.5](https://github.com/ethereum/solidity/releases/tag/v0.6.5), Solidity introduced the 


### PR DESCRIPTION
- In preparation of adding category labels, this PR adds the categories to the headers (for all blog posts)
- Aligns headers to follow header rules for all blog posts
- Adds "This post was originally published on XXX" to posts copied from the Ethereum Blog.
