### PR TITLE
Require github-pages 206 at minimum

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@ source 'https://rubygems.org'
 #gem "jekyll", "~> 3.6"
 
 group :jekyll_plugins do 
-  gem "github-pages"
-  gem 'jekyll-paginate'
+  gem "github-pages", "206"
+  gem "jekyll-paginate"
 end
 
 # enable tzinfo-data for local build

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,9 +31,9 @@ GEM
     ffi (1.12.2)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
-    github-pages (204)
+    github-pages (206)
       github-pages-health-check (= 1.16.1)
-      jekyll (= 3.8.5)
+      jekyll (= 3.8.7)
       jekyll-avatar (= 0.7.0)
       jekyll-coffeescript (= 1.1.1)
       jekyll-commonmark-ghpages (= 0.1.6)
@@ -72,7 +72,7 @@ GEM
       mercenary (~> 0.3)
       minima (= 2.5.1)
       nokogiri (>= 1.10.4, < 2.0)
-      rouge (= 3.13.0)
+      rouge (= 3.19.0)
       terminal-table (~> 1.4)
     github-pages-health-check (1.16.1)
       addressable (~> 2.3)
@@ -86,7 +86,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.5)
+    jekyll (3.8.7)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -215,7 +215,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rouge (3.13.0)
+    rouge (3.19.0)
     ruby-enum (0.8.0)
       i18n
     rubyzip (2.3.0)
@@ -242,7 +242,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  github-pages
+  github-pages (= 206)
   jekyll-paginate
 
 BUNDLED WITH


### PR DESCRIPTION
This upgrades the rouge dependency which introduces Solidity syntax highlighting

Fixes #34, now that https://github.com/github/pages-gem/pull/683 was merged (well a version of it).