### PR TITLE
Tweak bytes truncation example in 0.8.5 announcement to make calls correct

### DIFF
--- a/_posts/2021-06-10-solidity-0.8.5-release-announcement.md
+++ b/_posts/2021-06-10-solidity-0.8.5-release-announcement.md
@@ -22,12 +22,12 @@ This release introduces the ability to convert ``bytes`` and ``bytes`` slices to
 In case a byte array is longer than the target fixed bytes type, it will be truncated at the end:
 
 ```solidity
-function f(bytes calldata c) public view returns (bytes8) {
+function f(bytes memory c) public pure returns (bytes8) {
 	// If c is longer than 8 bytes, truncation happens
 	return bytes8(c); 
 }
 ```
-Calling ``f("12345678")`` will return ``"12345678"``, as will calling it as ``f("1234567890")``.
+Calling ``f("12345678")`` in Solidity code will return ``"12345678"``, as will calling it as ``f("1234567890")``.
 If the array is shorter than the target fixed type, it will be padded with zeros at the end, so
 calling ``f("1234")`` will return ``"1234"``.
 


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/11561.