### PR TITLE
Explainer on user-defined operators: whitespace tweaks

### DIFF
--- a/_posts/2023-02-22-user-defined-operators.md
+++ b/_posts/2023-02-22-user-defined-operators.md
@@ -216,7 +216,6 @@ function yoloDiv(U8 x, U8 y) pure returns (U8 z) {
 contract C {
     function divAddNoOverflow(U8 a, U8 b, U8 c) external pure returns (U8) {
         return a / (b + c);
-
     }
 }
 ```

--- a/_posts/2023-02-22-user-defined-operators.md
+++ b/_posts/2023-02-22-user-defined-operators.md
@@ -127,6 +127,7 @@ Since currently there are no implicit conversions allowed to and from UDVTs, use
 must always be invoked with exact types.
 
 The following operators can be defined:
+
 | Category   | Operators                        |
 |------------|----------------------------------|
 | Bitwise    | `&`, `\|`, `^`,  `~`             |


### PR DESCRIPTION
One of the tables is broken due to missing whitespace.

Also, one of the examples has superfluous whitespace.