### PR TITLE
Fix outdated Certora link in "Solidity ABI Decoder Bug For Multi-Dimensional Memory Arrays" blog

### DIFF
--- a/_posts/2021-04-21-decoding-from-memory-bug.md
+++ b/_posts/2021-04-21-decoding-from-memory-bug.md
@@ -10,7 +10,7 @@ category: Security Alerts
 
 On April 5th, 2021, a bug in the Solidity ABI decoder v2 was reported by
 John Toman of the Certora development team. Certora's bug disclosure post
-can be found here: [Memory Isolation Violation in Deserialization Code](http://web.archive.org/web/20210409180710/https://www.certora.com/blog/deserialization.html).
+can be found here: [Memory Isolation Violation in Deserialization Code](https://medium.com/certora/memory-isolation-violation-in-deserialization-code-certora-bug-disclosure-aece7cd00562).
 
 The bug is fixed with [Solidity version 0.8.4](https://github.com/ethereum/solidity/releases/tag/v0.8.4)
 released on April 21st, 2021. **The bug is present in all prior versions of ABI coder v2.**

--- a/_posts/2021-04-21-decoding-from-memory-bug.md
+++ b/_posts/2021-04-21-decoding-from-memory-bug.md
@@ -10,7 +10,7 @@ category: Security Alerts
 
 On April 5th, 2021, a bug in the Solidity ABI decoder v2 was reported by
 John Toman of the Certora development team. Certora's bug disclosure post
-can be found here: [Memory Isolation Violation in Deserialization Code](https://www.certora.com/blog/deserialization.html).
+can be found here: [Memory Isolation Violation in Deserialization Code](http://web.archive.org/web/20210409180710/https://www.certora.com/blog/deserialization.html).
 
 The bug is fixed with [Solidity version 0.8.4](https://github.com/ethereum/solidity/releases/tag/v0.8.4)
 released on April 21st, 2021. **The bug is present in all prior versions of ABI coder v2.**


### PR DESCRIPTION
I have reached out to the Certora team to find out why the current link has been removed. Please do not merge this PR until we are sure it will not be added back. I have opened this PR in the first line to track the history that it was once removed.

The h/t goes to @0xriptide for discovering this!