### PR TITLE
Add post author to RSS feed items

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -18,6 +18,7 @@ layout: null
         <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
         <link>{{ site.url }}{{ post.url }}</link>
         <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
+        <author>{{ post.author }}</author>
       </item>
     {% endfor %}
   </channel>


### PR DESCRIPTION
## Description
Currently working to rebuild the Solidity Lang core website, and in this looking to pull from the blog's RSS feed to populate the most recent entries. Plan was to include the author of the post in this preview as well, but this information is not currently added to the RSS feed being generated.

PR adds `<author>{{ post.author }}</author>` to the `feed.xml` file to populate the `author` front matter property for each post within the RSS feed.