### PR TITLE
Update READMEs to direct to new repo

### DIFF
--- a/EDITOR_README.md
+++ b/EDITOR_README.md
@@ -1,3 +1,5 @@
+## 🚨 This repository has been archived. Please visit the new home for the Solidity website codebase at [`ethereum/solidity-website`](https://github.com/ethereum/solidity-website)
+
 # Blog Editor Instructions
 
 See the main README to see how to add a blog post to the `_posts` folder in the `master` branch before following the steps below.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## 🚨 This repository has been archived. Please visit the new home for the Solidity website and blog codebase at [`ethereum/solidity-website`](https://github.com/ethereum/solidity-website)
+
 # Solidity Blog
 
 The blog can reached at [blog.soliditylang.org](https://blog.soliditylang.org). These are the sources for the Solidity blog. Read [this for editing instructions](./EDITOR_README.md).


### PR DESCRIPTION
Updates the README noting the repo has been archived, and directs users to the new repo.

The [new blog](https://blog.soliditylang.org) is live (🎉), so with this PR this repo can safely be archived and made read-only.

New repo at [ethereum/solidity-website](https://github.com/ethereum/solidity-website)

---

Note, the blog now lives with the main Solidity website, under the `/blog` path. This can be accessed at https://soliditylang.org/blog. Importantly, the structure of the blog paths (ie, `YYYY/MM/DD/post-name`) remains unchanged, and redirects are in place to forward any old links to the new site, so https://blog.soliditylang.org/ and any subpaths should redirect appropriately.